### PR TITLE
fix arguments order in sample code

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -28,7 +28,7 @@ package (
     "github.com/DMMcomLabo/dmm-go-sdk"
 )
 
-client := dmm.New("foobarbazbuzz", "dummy-990")
+client := dmm.New("dummy-990", "foobarbazbuzz")
 api := client.Product
 api.SetSite(SITE_ALLAGES)
 api.SetService("mono")
@@ -51,7 +51,7 @@ package (
     "github.com/DMMcomLabo/dmm-go-sdk/api"
 )
 
-rst, err := NewProductService("foobarbazbuzz", "dummy-999").SetSite(SITE_ADULT).SetLength(1).Execute()
+rst, err := NewProductService("dummy-999", "foobarbazbuzz" ).SetSite(SITE_ADULT).SetLength(1).Execute()
 if err != nil {
     fmt.Println(err)
 } else {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ package (
     "github.com/DMMcomLabo/dmm-go-sdk"
 )
 
-client := dmm.New("foobarbazbuzz", "dummy-990")
+client := dmm.New("dummy-990", "foobarbazbuzz")
 api := client.Product
 api.SetSite(SiteGeneral)
 api.SetService("mono")
@@ -58,7 +58,7 @@ package (
     "github.com/DMMcomLabo/dmm-go-sdk/api"
 )
 
-rst, err := NewProductService("foobarbazbuzz", "dummy-999").SetSite(SITE_ADULT).SetLength(1).Execute()
+rst, err := NewProductService( "dummy-999", "foobarbazbuzz").SetSite(SITE_ADULT).SetLength(1).Execute()
 if err != nil {
     fmt.Println(err)
 } else {


### PR DESCRIPTION
README.mdのサンプルコードで、APIIDとアフィリエイトIDの順序が間違っているのを修正しました。
