### PR TITLE
Add buildAPIEndpoint function

### DIFF
--- a/api/actress.go
+++ b/api/actress.go
@@ -2,9 +2,10 @@ package api
 
 import (
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"net/url"
 	"strconv"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 const (
@@ -278,5 +279,11 @@ func (srv *ActressService) BuildRequestURL() (string, error) {
 		queries.Set("height", srv.Height)
 	}
 
-	return APIBaseURL + "/ActressSearch?" + queries.Encode(), nil
+	u, err := buildAPIEndpoint("ActressSearch")
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = queries.Encode()
+
+	return u.String(), nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"path"
 	"regexp"
 	"strings"
 )
@@ -92,4 +94,16 @@ func ValidateRange(target, min, max int64) bool {
 // GetAPIVersionはAPIのバージョンを返します。
 func GetAPIVersion() string {
 	return APIVersion
+}
+
+// buildAPIEndpoint returns API Endpoint path.
+//
+// buildAPIEndpointはAPIエンドポイントのフルパスを組み立てて返します。
+func buildAPIEndpoint(p string) (*url.URL, error) {
+	u, err := url.Parse(APIBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("Parse error: %#v", err)
+	}
+	u.Path = path.Join(u.Path, p)
+	return u, err
 }

--- a/api/author.go
+++ b/api/author.go
@@ -2,9 +2,10 @@ package api
 
 import (
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"net/url"
 	"strconv"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 type AuthorService struct {
@@ -182,5 +183,12 @@ func (srv *AuthorService) BuildRequestURL() (string, error) {
 	if srv.Initial != "" {
 		queries.Set("initial", srv.Initial)
 	}
-	return APIBaseURL + "/AuthorSearch?" + queries.Encode(), nil
+
+	u, err := buildAPIEndpoint("AuthorSearch")
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = queries.Encode()
+
+	return u.String(), nil
 }

--- a/api/floor.go
+++ b/api/floor.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"net/url"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 type FloorService struct {
@@ -92,5 +93,11 @@ func (srv *FloorService) BuildRequestURL() (string, error) {
 	queries.Set("api_id", srv.ApiID)
 	queries.Set("affiliate_id", srv.AffiliateID)
 
-	return APIBaseURL + "/FloorList?" + queries.Encode(), nil
+	u, err := buildAPIEndpoint("FloorList")
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = queries.Encode()
+
+	return u.String(), nil
 }

--- a/api/genre.go
+++ b/api/genre.go
@@ -2,9 +2,10 @@ package api
 
 import (
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"net/url"
 	"strconv"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 type GenreService struct {
@@ -182,5 +183,12 @@ func (srv *GenreService) BuildRequestURL() (string, error) {
 	if srv.Initial != "" {
 		queries.Set("initial", srv.Initial)
 	}
-	return APIBaseURL + "/GenreSearch?" + queries.Encode(), nil
+
+	u, err := buildAPIEndpoint("GenreSearch")
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = queries.Encode()
+
+	return u.String(), nil
 }

--- a/api/maker.go
+++ b/api/maker.go
@@ -2,9 +2,10 @@ package api
 
 import (
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"net/url"
 	"strconv"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 type MakerService struct {
@@ -182,5 +183,12 @@ func (srv *MakerService) BuildRequestURL() (string, error) {
 	if srv.Initial != "" {
 		queries.Set("initial", srv.Initial)
 	}
-	return APIBaseURL + "/MakerSearch?" + queries.Encode(), nil
+
+	u, err := buildAPIEndpoint("MakerSearch")
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = queries.Encode()
+
+	return u.String(), nil
 }

--- a/api/product.go
+++ b/api/product.go
@@ -2,9 +2,10 @@ package api
 
 import (
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"net/url"
 	"strconv"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 const (
@@ -377,5 +378,12 @@ func (srv *ProductService) BuildRequestURL() (string, error) {
 	if srv.Stock != "" {
 		queries.Set("mono_stock", srv.Stock)
 	}
-	return APIBaseURL + "/ItemList?" + queries.Encode(), nil
+
+	u, err := buildAPIEndpoint("ItemList")
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = queries.Encode()
+
+	return u.String(), nil
 }

--- a/api/series.go
+++ b/api/series.go
@@ -2,9 +2,10 @@ package api
 
 import (
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"net/url"
 	"strconv"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 type SeriesService struct {
@@ -182,5 +183,12 @@ func (srv *SeriesService) BuildRequestURL() (string, error) {
 	if srv.Initial != "" {
 		queries.Set("initial", srv.Initial)
 	}
-	return APIBaseURL + "/SeriesSearch?" + queries.Encode(), nil
+
+	u, err := buildAPIEndpoint("SeriesSearch")
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = queries.Encode()
+
+	return u.String(), nil
 }


### PR DESCRIPTION
Use `url.URL` struct to build API Endpoint path.

we can avoid these common errors.
- `https://api.dmm.com/affiliate/v3ActressSearch`
- `https://api.dmm.com/affiliate/v3//ActressSearch`

Thanks!
