### PR TITLE
fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,39 +30,46 @@ $ go get gopkg.in/dmmlabo/dmm-go-sdk.v1
 ## 使用例 (商品検索APIの場合)
 
 ```
-package (
+package main
+
+import (
     "fmt"
     "github.com/dmmlabo/dmm-go-sdk"
+    "github.com/dmmlabo/dmm-go-sdk/api"
 )
 
-client := dmm.New("dummy-990", "foobarbazbuzz")
-api := client.Product
-api.SetSite(SiteGeneral)
-api.SetService("mono")
-api.SetFloor("dvd")
-api.SetSort("date")
-api.SetLength(1)
-result, err := api.Execute()
-if err != nil {
-    fmt.Println(err)
-} else {
-    fmt.Println(result)
+func main() {
+	client := dmm.New("dummy-990", "foobarbazbuzz")
+	dmmapi := client.Product
+	dmmapi.SetSite(api.SiteGeneral)
+	dmmapi.SetService("mono")
+	dmmapi.SetFloor("dvd")
+	dmmapi.SetSort("date")
+	dmmapi.SetLength(1)
+	result, err := api.Execute()
+	if err != nil {
+    	fmt.Println(err)
+	} else {
+    	fmt.Println(result)
+	}
 }
 ```
 
 もしくは
 
 ```
-package (
+package main
+import (
     "fmt"
     "github.com/dmmlabo/dmm-go-sdk/api"
 )
-
-rst, err := NewProductService( "dummy-999", "foobarbazbuzz").SetSite(SITE_ADULT).SetLength(1).Execute()
-if err != nil {
-    fmt.Println(err)
-} else {
-    fmt.Println(rst)
+func main() {
+	rst, err := NewProductService( "dummy-999", "foobarbazbuzz").SetSite(api.SiteAdult).SetLength(1).Execute()
+	if err != nil {
+    	fmt.Println(err)
+	} else {
+    	fmt.Println(rst)
+	}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ func main() {
 	dmmapi.SetFloor("dvd")
 	dmmapi.SetSort("date")
 	dmmapi.SetLength(1)
-	result, err := api.Execute()
+	result, err := dmmapi.Execute()
 	if err != nil {
     	fmt.Println(err)
 	} else {
@@ -64,7 +64,7 @@ import (
     "github.com/dmmlabo/dmm-go-sdk/api"
 )
 func main() {
-	rst, err := NewProductService( "dummy-999", "foobarbazbuzz").SetSite(api.SiteAdult).SetLength(1).Execute()
+	rst, err := api.NewProductService( "dummy-999", "foobarbazbuzz").SetSite(api.SiteAdult).SetLength(1).Execute()
 	if err != nil {
     	fmt.Println(err)
 	} else {

--- a/docs/actress.md
+++ b/docs/actress.md
@@ -42,7 +42,7 @@ import (
 )
 
 func main() {
-	rst, err := NewActressService("foobarbazbuzz", "dummy-999").SetLength(1).Execute()
+	rst, err := api.NewActressService("foobarbazbuzz", "dummy-999").SetLength(1).Execute()
 	if err != nil {
 	  fmt.Println(err)
 	} else {

--- a/docs/actress.md
+++ b/docs/actress.md
@@ -2,44 +2,52 @@
 #### 使用例
 
 ```go
-package (  
+package main
+import (  
   "fmt"  
   "github.com/DMMcomLabo/dmm-go-sdk"  
 )  
 
-client := dmm.New("foobarbazbuzz", "dummy-990")
-api := client.Actress
-api.SetInitial("あ")
-api.SetKeyword("あさみ")
-api.SetBust("90")
-api.SetWaist("-60")
-api.SetHip("85-90")
-api.SetHeight("160")
-api.SetBirthday("19900101")
-api.SetSort("-name")
-api.SetLength(20)
-api.SetOffset(1)
-result, err := api.Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(result)
+func main() {
+
+	client := dmm.New("foobarbazbuzz", "dummy-990")
+	dmmapi := client.Actress
+	dmmapi.SetInitial("あ")
+	dmmapi.SetKeyword("あさみ")
+	dmmapi.SetBust("90")
+	dmmapi.SetWaist("-60")
+	dmmapi.SetHip("85-90")
+	dmmapi.SetHeight("160")
+	dmmapi.SetBirthday("19900101")
+	dmmapi.SetSort("-name")
+	dmmapi.SetLength(20)
+	dmmapi.SetOffset(1)
+	result, err := dmmapi.Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(result)
+	}
 }
 ```
 
 もしくは以下のように1行で書くこともできます。
 
 ```go
-package (
+package main
+ 
+import (
   "fmt"
   "github.com/DMMcomLabo/dmm-go-sdk/api"
 )
 
-rst, err := NewActressService("foobarbazbuzz", "dummy-999").SetLength(1).Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(rst)
+func main() {
+	rst, err := NewActressService("foobarbazbuzz", "dummy-999").SetLength(1).Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(rst)
+	}
 }
 ```
 

--- a/docs/author.md
+++ b/docs/author.md
@@ -34,7 +34,7 @@ import (
 )
 
 func main() {
-	rst, err := NewProductService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
+	rst, err := api.NewProductService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
 	if err != nil {
 	  fmt.Println(err)
 	} else {

--- a/docs/author.md
+++ b/docs/author.md
@@ -2,38 +2,44 @@
 #### 使用例
 
 ```go
-package (  
+package main
+import (  
   "fmt"  
   "github.com/DMMcomLabo/dmm-go-sdk"  
 )  
 
-client := dmm.New("foobarbazbuzz", "dummy-990")
-api := client.Author
-api.SetFloorID("40")
-api.SetInitial("あ")
-api.SetLength(100)
-api.SetOffset(1)
-result, err := api.Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(result)
+func main() {
+	client := dmm.New("foobarbazbuzz", "dummy-990")
+	dmmapi := client.Author
+	dmmapi.SetFloorID("40")
+	dmmapi.SetInitial("あ")
+	dmmapi.SetLength(100)
+	dmmapi.SetOffset(1)
+	result, err := dmmapi.Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(result)
+	}
 }
 ```
 
 もしくは以下のように1行で書くこともできます。
 
 ```go
-package (
+package main
+import (
   "fmt"
   "github.com/DMMcomLabo/dmm-go-sdk/api"
 )
 
-rst, err := NewProductService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(rst)
+func main() {
+	rst, err := NewProductService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(rst)
+	}
 }
 ```
 

--- a/docs/floor.md
+++ b/docs/floor.md
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	rst, err := NewFloorService("foobarbazbuzz", "dummy-999").Execute()
+	rst, err := api.NewFloorService("foobarbazbuzz", "dummy-999").Execute()
 	if err != nil {
 	  fmt.Println(err)
 	} else {

--- a/docs/floor.md
+++ b/docs/floor.md
@@ -2,34 +2,40 @@
 #### 使用例
 
 ```go
-package (  
+package main 
+import (  
   "fmt"  
   "github.com/DMMcomLabo/dmm-go-sdk"  
 )  
 
-client := dmm.New("foobarbazbuzz", "dummy-990")
-api := client.Floor
-result, err := api.Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(result)
+func main() {
+	client := dmm.New("foobarbazbuzz", "dummy-990")
+	dmmapi := client.Floor
+	result, err := dmmapi.Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(result)
+	}
 }
 ```
 
 もしくは以下のように1行で書くこともできます。
 
 ```go
-package (
+package main
+import (
   "fmt"
   "github.com/DMMcomLabo/dmm-go-sdk/api"
 )
 
-rst, err := NewFloorService("foobarbazbuzz", "dummy-999").Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(rst)
+func main() {
+	rst, err := NewFloorService("foobarbazbuzz", "dummy-999").Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(rst)
+	}
 }
 ```
 

--- a/docs/genre.md
+++ b/docs/genre.md
@@ -2,38 +2,43 @@
 #### 使用例
 
 ```go
-package (  
+package main
+import (  
   "fmt"  
   "github.com/DMMcomLabo/dmm-go-sdk"  
 )  
 
-client := dmm.New("foobarbazbuzz", "dummy-990")
-api := client.Genre
-api.SetFloorID("40")
-api.SetInitial("あ")
-api.SetLength(100)
-api.SetOffset(1)
-result, err := api.Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(result)
+func main() {
+	client := dmm.New("foobarbazbuzz", "dummy-990")
+	dmmapi := client.Genre
+	dmmapi.SetFloorID("40")
+	dmmapi.SetInitial("あ")
+	dmmapi.SetLength(100)
+	dmmapi.SetOffset(1)
+	result, err := dmmapi.Execute()
+	if err != nil {
+  	fmt.Println(err)
+	} else {
+	  fmt.Println(result)
+	}
 }
 ```
 
 もしくは以下のように1行で書くこともできます。
 
 ```go
-package (
+package main
+import (
   "fmt"
   "github.com/DMMcomLabo/dmm-go-sdk/api"
 )
-
-rst, err := NewGenreService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(rst)
+func main() {
+	rst, err := NewGenreService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(rst)
+	}
 }
 ```
 

--- a/docs/genre.md
+++ b/docs/genre.md
@@ -33,7 +33,7 @@ import (
   "github.com/DMMcomLabo/dmm-go-sdk/api"
 )
 func main() {
-	rst, err := NewGenreService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
+	rst, err := api.NewGenreService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
 	if err != nil {
 	  fmt.Println(err)
 	} else {

--- a/docs/maker.md
+++ b/docs/maker.md
@@ -2,38 +2,44 @@
 #### 使用例
 
 ```go
-package (  
+package main
+import (  
   "fmt"  
   "github.com/DMMcomLabo/dmm-go-sdk"  
 )  
 
-client := dmm.New("foobarbazbuzz", "dummy-990")
-api := client.Maker
-api.SetFloorID("40")
-api.SetInitial("あ")
-api.SetLength(100)
-api.SetOffset(1)
-result, err := api.Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(result)
+func main() {
+	client := dmm.New("foobarbazbuzz", "dummy-990")
+	dmmapi := client.Maker
+	dmmapi.SetFloorID("40")
+	dmmapi.SetInitial("あ")
+	dmmapi.SetLength(100)
+	dmmapi.SetOffset(1)
+	result, err := dmmapi.Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(result)
+	}
 }
 ```
 
 もしくは以下のように1行で書くこともできます。
 
 ```go
-package (
+package main
+import (
   "fmt"
   "github.com/DMMcomLabo/dmm-go-sdk/api"
 )
 
-rst, err := NewMakerService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(rst)
+func main() {
+	rst, err := NewMakerService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(rst)
+	}
 }
 ```
 

--- a/docs/product.md
+++ b/docs/product.md
@@ -2,39 +2,46 @@
 ## 使用例
 
 ```
-package (  
+package main
+import (  
   "fmt"  
-  "github.com/DMMcomLabo/dmm-go-sdk"  
+  "github.com/DMMcomLabo/dmm-go-sdk"
+  "github.com/DMMcomLabo/dmm-go-sdk/api"
 )  
 
-client := dmm.New("foobarbazbuzz", "dummy-990")
-api := client.Product
-api.SetSite(SiteGeneral)
-api.SetService("mono")
-api.SetFloor("dvd")
-api.SetSort("date")
-api.SetLength(1)
-result, err := api.Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(result)
+func main() {
+	client := dmm.New("foobarbazbuzz", "dummy-990")
+	dmmapi := client.Product
+	dmmapi.SetSite(api.SiteGeneral)
+	dmmapi.SetService("mono")
+	dmmapi.SetFloor("dvd")
+	dmmapi.SetSort("date")
+	dmmapi.SetLength(1)
+	result, err := dmmapi.Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(result)
+	}
 }
 ```
 
 もしくは以下のように1行で書くこともできます。
 
 ```
-package (
+package main
+import (
   "fmt"
   "github.com/DMMcomLabo/dmm-go-sdk/api"
 )
 
-rst, err := NewProductService("foobarbazbuzz", "dummy-999").SetSite(SiteAdult).SetLength(1).Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(rst)
+func main() {
+	rst, err := NewProductService("foobarbazbuzz", "dummy-999").SetSite(SiteAdult).SetLength(1).Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(rst)
+	}
 }
 ```
 

--- a/docs/product.md
+++ b/docs/product.md
@@ -36,7 +36,7 @@ import (
 )
 
 func main() {
-	rst, err := NewProductService("foobarbazbuzz", "dummy-999").SetSite(SiteAdult).SetLength(1).Execute()
+	rst, err := api.NewProductService("foobarbazbuzz", "dummy-999").SetSite(api.SiteAdult).SetLength(1).Execute()
 	if err != nil {
 	  fmt.Println(err)
 	} else {

--- a/docs/series.md
+++ b/docs/series.md
@@ -35,7 +35,7 @@ import (
 )
 
 func main() {
-	rst, err := NewSeriesService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
+	rst, err := api.NewSeriesService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
 	if err != nil {
 	  fmt.Println(err)
 	} else {

--- a/docs/series.md
+++ b/docs/series.md
@@ -2,38 +2,45 @@
 #### 使用例
 
 ```go
-package (  
+package main
+import (  
   "fmt"  
   "github.com/DMMcomLabo/dmm-go-sdk"  
 )  
 
-client := dmm.New("foobarbazbuzz", "dummy-990")
-api := client.Series
-api.SetFloorID("40")
-api.SetInitial("あ")
-api.SetLength(100)
-api.SetOffset(1)
-result, err := api.Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(result)
-}
+func main() {
+	client := dmm.New("foobarbazbuzz", "dummy-990")
+	dmmapi := client.Series
+	dmmapi.SetFloorID("40")
+	dmmapi.SetInitial("あ")
+	dmmapi.SetLength(100)
+	dmmapi.SetOffset(1)
+	result, err := dmmapi.Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(result)
+	}
+}	
+
 ```
 
 もしくは以下のように1行で書くこともできます。
 
 ```go
-package (
+package main
+import (
   "fmt"
   "github.com/DMMcomLabo/dmm-go-sdk/api"
 )
 
-rst, err := NewSeriesService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
-if err != nil {
-  fmt.Println(err)
-} else {
-  fmt.Println(rst)
+func main() {
+	rst, err := NewSeriesService("foobarbazbuzz", "dummy-999").SetFloorID("40").SetLength(1).Execute()
+	if err != nil {
+	  fmt.Println(err)
+	} else {
+	  fmt.Println(rst)
+	}
 }
 ```
 


### PR DESCRIPTION
* There is `api` package in `dmm-go-sdk`. So, var `api` is not recommended. I changed var `api` to `dmmapi`.
* The way to importing libraries was wrong.
* `SiteGeneral` and  `SiteAdult` are constants in `dmm-go-sdk/api`.
* Put examples into main() function.