### PR TITLE
fix typo Item#URLMoble to URLMobile

### DIFF
--- a/api/product.go
+++ b/api/product.go
@@ -62,7 +62,7 @@ type Item struct {
 	Stock              string             `mapstructure:"stock"`
 	Title              string             `mapstructure:"title"`
 	URL                string             `mapstructure:"URL"`
-	URLMoble           string             `mapstructure:"URLsp"`
+	URLMobile          string             `mapstructure:"URLsp"`
 	Volume             string             `mapstructure:"volume"`
 	ImageURL           ImageURLList       `mapstructure:"imageURL"`
 	SampleImageURL     SampleImageURLList `mapstructure:"sampleImageURL"`


### PR DESCRIPTION
In api/product.go, struct Item, URLMoble is incorrect name. Because this parameter means URLsp(Smart Phone), URLMobile is correct name.